### PR TITLE
Add continuous integration with CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,39 @@
+# iOS CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/ios-migrating-from-1-2/ for more details
+#
+version: 2
+jobs:
+  build:
+
+    # Specify the Xcode version to use
+    macos:
+      xcode: "8.3.3"
+
+    steps:
+      - checkout
+
+      # Install CocoaPods
+      - run:
+          name: Install CocoaPods
+          command: pod install
+
+      # Build the app and run tests
+      - run:
+          name: Build and run tests
+          command: fastlane scan
+          environment:
+            SCAN_DEVICE: iPhone 6
+            SCAN_SCHEME: WebTests
+
+      # Collect XML test results data to show in the UI,
+      # and save the same XML files under test-results folder
+      # in the Artifacts tab
+      - store_test_results:
+          path: test_output/report.xml
+      - store_artifacts:
+          path: /tmp/test-results
+          destination: scan-test-results
+      - store_artifacts:
+          path: ~/Library/Logs/scan
+          destination: scan-logs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,9 @@ jobs:
       # Install CocoaPods
       - run:
           name: Install CocoaPods
-          command: pod install
+          command: |
+            curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
+            pod install
 
       - save_cache:
           key: ios-pods-cache-{{ checksum "Podfile" }}-{{ checksum "Podfile.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
 
     # Specify the Xcode version to use
     macos:
-      xcode: "8.3.3"
+      xcode: "9.4.1"
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,10 +13,19 @@ jobs:
     steps:
       - checkout
 
+      - restore_cache:
+          keys:
+            - ios-pods-cache-{{ checksum "Podfile" }}-{{ checksum "Podfile.lock" }}
+
       # Install CocoaPods
       - run:
           name: Install CocoaPods
           command: pod install
+
+      - save_cache:
+          key: ios-pods-cache-{{ checksum "Podfile" }}-{{ checksum "Podfile.lock" }}
+          paths:
+            - Pods/
 
       # Build the app and run tests
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           command: fastlane scan
           environment:
             SCAN_DEVICE: iPhone 6
-            SCAN_SCHEME: WebTests
+            SCAN_SCHEME: ParallelCodingExample1
 
       # Collect XML test results data to show in the UI,
       # and save the same XML files under test-results folder

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,8 @@ jobs:
           environment:
             SCAN_DEVICE: iPhone 6
             SCAN_SCHEME: ParallelCodingExample1
+            LC_ALL: en_US.UTF-8
+            LANG: en_US.UTF-8
 
       # Collect XML test results data to show in the UI,
       # and save the same XML files under test-results folder


### PR DESCRIPTION
CircleCI is a continuous integration product that lets us build an app and run our tests every time we push a new commit to any branch in the git repo.

CircleCI is free for open source projects that are not macOS-based, but [any macOS project costs](https://circleci.com/pricing/#build-os-x) some money, probably since CircleCI has to specially maintain Mac hardware running in the cloud.

To allow this Xcode project to quickly be built by many people all working in parallel, having a solid continuous integration setup seems essential.

These commits were my steps for adding continuous integration to the Xcode default new project. 

A couple notes about where you can see I hiccuped a little bit: 
* The `.circleci/config.yml` file given by default from CircleCI specifies Xcode 8.x - I overlooked that when I copy/pasted it!
* Installing Cocoapods takes a semi-long time - the [last commit](https://circleci.com/gh/karlbecker/parallel-coding-example1/30) uses a technique that sped up total build time by about 50% (dropped ~4 minutes total off the build)
* I used a cache to try to speed up the Pod install process - I'll want to inspect how this caching might harm build speeds as we change what's in the Podfile