### PR TITLE
Update Nimble to eliminate warning on Xcode 9.4.1

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,11 +1,11 @@
 # Uncomment the next line to define a global platform for your project
-# platform :ios, '9.0'
+platform :ios, '11.4'
 
 use_frameworks!
 
 def testing_pods
     pod 'Quick'
-    pod 'Nimble'
+    pod 'Nimble', :git => 'https://github.com/Quick/Nimble.git', :branch => '7.x-branch'
 end
 
 target 'ParallelCodingExample1' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,15 +1,25 @@
 PODS:
-  - Nimble (7.1.2)
+  - Nimble (7.1.3)
   - Quick (1.3.0)
 
 DEPENDENCIES:
-  - Nimble
+  - Nimble (from `https://github.com/Quick/Nimble.git`, branch `7.x-branch`)
   - Quick
 
+EXTERNAL SOURCES:
+  Nimble:
+    :branch: 7.x-branch
+    :git: https://github.com/Quick/Nimble.git
+
+CHECKOUT OPTIONS:
+  Nimble:
+    :commit: d7f6779e7a60a350d4ddbf3ace3721e6b1ee3d2d
+    :git: https://github.com/Quick/Nimble.git
+
 SPEC CHECKSUMS:
-  Nimble: 3835ba9f459daa6b347f8a8e110aaae8ca1920a8
+  Nimble: 2839b01d1b31f6a6a7777a221f0d91cf52e8e27b
   Quick: 03278013f71aa05fe9ecabc94fbcc6835f1ee76f
 
-PODFILE CHECKSUM: 856802a9cd145e254ea3c0dbff1c70ee70757e38
+PODFILE CHECKSUM: a6e73554f8d023350f860fd887e7dab4fa49b554
 
 COCOAPODS: 1.4.0


### PR DESCRIPTION
## Summary - 

<!--Required: The high level goal of the desired outcome of this PR. This will be included in the auto-generated release notes for a prod deployment.-->

Eliminate the 1 compiler warning that was popping up in Xcode 9.4

## Description

<!-- Optional: For going into further detail on the change. Screenshots, gifs, review guidance, etc-->

The issue is documented here: https://github.com/Quick/Nimble/issues/540

Looks like Nimble's master branch hasn't been updated to include this fix yet, so just pulling in the version that fixes this. 

## Implementation Notes

<!-- Optional: Any file / API changes done to accomplish the larger goal laid out in the summary.-->

1. Should eliminate grabbing from this branch in the future once this is fixed.
2. Already did this while making changes for #5 , but cherry-picked this change since it is useful for the project even if that PR doesn't get merged

## Deploy Precautions

- None
